### PR TITLE
Add external prometheus endpoint to k8s setup

### DIFF
--- a/k8s/base/prometheus.yaml
+++ b/k8s/base/prometheus.yaml
@@ -174,3 +174,17 @@ spec:
       protocol: TCP
       port: 9099
       targetPort: 9099
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-external
+spec:
+  selector:
+    app: prometheus
+  type: LoadBalancer
+  ports:
+    - name: prometheus
+      port: 80
+      targetPort: 9099


### PR DESCRIPTION
This setup needs hardening with access control, https, and so on
but as a base example this should still be helpful.

Thanks to lutter on discored for help with this.