### PR TITLE
Use correct server env var names in the instructions: SERVER_DB_USERNAME -> SERVER_DB_USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ NPM, Docker, or directly from source below.
   export SERVER_HOST=<postgres-host>
   export SERVER_PORT=<postgres-port>
   export SERVER_DB_NAME=<postgres-db> # Don't use the same as your Graph Node(s)!
-  export SERVER_DB_USERNAME=<postgres-username>
+  export SERVER_DB_USER=<postgres-username>
   export SERVER_DB_PASSWORD=<postgres-password>
 
   graph-indexer-service start \


### PR DESCRIPTION
Resolves #6  
The env name `SERVER_DB_USERNAME` in the npm installation instructions was incorrect; it has now been updated to the correct value `SERVER_DB_USER`. 