### PR TITLE
fix typo in port forward docs

### DIFF
--- a/guides/indexer-management.md
+++ b/guides/indexer-management.md
@@ -26,7 +26,7 @@ CLI does not need to run on the same server or cluster.
 4. Allow accessing the indexer management API of the `indexer-agent`
    from your current machine.
    ```sh
-   kubectl port-forward pod/<indexer-agent-pod> 8000:18000
+   kubectl port-forward pod/<indexer-agent-pod> 18000:8000
    ```
 5. Connect the Indexer CLI to the indexer management API.
     ```yaml


### PR DESCRIPTION
The port numbers in the port-forward are reversed. kubectl's port forward takes the local port first and the remote port second.

In order to make `graph indexer connect http://localhost:18000/` work it needs to be

`kubectl port-forward pod/<indexer-agent-pod> 18000:8000`

From the docs:
>   // Listen on port 8888 locally, forwarding to 5000 in the pod
>   kubectl port-forward pod/mypod 8888:5000