### PR TITLE
Terraform: Allow to configure several parameters

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,6 +34,10 @@ resource "google_container_cluster" "cluster" {
   remove_default_node_pool = true
   initial_node_count       = 1
 
+  release_channel {
+    channel = var.release_channel
+  }
+
   network = "projects/${var.project}/global/networks/default"
 
   master_auth {
@@ -56,8 +60,10 @@ resource "google_container_node_pool" "default_pool" {
   node_count = var.sizes.default_pool
 
   node_config {
-    preemptible  = false
+    preemptible  = var.preemptible
     machine_type = var.machine_type
+    image_type   = var.image_type
+    disk_size_gb = var.disk_size_gb
 
     metadata = {
       disable-legacy-endpoints = "true"
@@ -71,6 +77,10 @@ resource "google_container_node_pool" "default_pool" {
       "https://www.googleapis.com/auth/service.management.readonly",
       "https://www.googleapis.com/auth/trace.append"
     ]
+
+    shielded_instance_config {
+      enable_secure_boot = var.secure_boot
+    }
   }
 }
 
@@ -80,8 +90,10 @@ resource "google_container_node_pool" "query_pool" {
   node_count = var.sizes.query_pool
 
   node_config {
-    preemptible  = false
+    preemptible  = var.preemptible
     machine_type = var.machine_type
+    image_type   = var.image_type
+    disk_size_gb = var.disk_size_gb
 
     metadata = {
       disable-legacy-endpoints = "true"
@@ -107,6 +119,10 @@ resource "google_container_node_pool" "query_pool" {
       "https://www.googleapis.com/auth/service.management.readonly",
       "https://www.googleapis.com/auth/trace.append"
     ]
+
+    shielded_instance_config {
+      enable_secure_boot = var.secure_boot
+    }
   }
 }
 
@@ -116,8 +132,10 @@ resource "google_container_node_pool" "index_pool" {
   node_count = var.sizes.index_pool
 
   node_config {
-    preemptible  = false
+    preemptible  = var.preemptible
     machine_type = var.machine_type
+    image_type   = var.image_type
+    disk_size_gb = var.disk_size_gb
 
     metadata = {
       disable-legacy-endpoints = "true"
@@ -143,6 +161,10 @@ resource "google_container_node_pool" "index_pool" {
       "https://www.googleapis.com/auth/service.management.readonly",
       "https://www.googleapis.com/auth/trace.append"
     ]
+
+    shielded_instance_config {
+      enable_secure_boot = var.secure_boot
+    }
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -41,6 +41,34 @@ variable "machine_type" {
   description = "The type of machine to use for kubernetes nodes"
 }
 
+variable "image_type" {
+  type = string
+  default = "COS"
+  description = "The image type to use for kubernetes nodes"
+}
+
+variable "disk_size_gb" {
+  type = number
+  default = 100
+  description = "The size of the boot disk on each kubernetes node, specified in GB"
+}
+
+variable "preemptible" {
+  default = false
+  description = "Whether to use preemptible machines for kubernetes nodes"
+}
+
+variable "secure_boot" {
+  default = false
+  description = "Whether to enable secure boot for kubernetes nodes"
+}
+
+variable "release_channel" {
+  type = string
+  default = "UNSPECIFIED"
+  description = "The release channel of the Kubernetes cluster"
+}
+
 # Possible values are listed at
 # https://cloud.google.com/sql/docs/postgres/create-instance
 variable "database_tier" {


### PR DESCRIPTION
This allows to configure several Terraform parameters. Contains the same changes as done on the Indexer repository: https://github.com/graphprotocol/indexer/pull/35

All parameters default to the current hard-coded values.

**Release channel**: This adds a variable to specify the release channel of the Kubernetes cluster.

Release channels keep the cluster updated automatically based on a configurable frequency, such as rapid, regular and stable: https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels

The previous config didn't use release channels and that's also the default in this PR. This currently maps to 1.15.

However, 1.15 matches the version in the "STABLE" release channel and we could think about making it the default. The update is in-place and doesn't require any node replacements.

**Preemptible**

Allows spinning up preemptible nodes on GKE.

**Disk size**

Allows to reduce or increase worker nodes' boot disk size.

**Secure boot** is turned off by default but there's really no harm in using it: https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes#secure_boot

It defauts to `false` so that people have to opt-in since it replaces all nodes.

**Image Type**: This allows to switch the VM image for worker nodes away from the default ContainerOS.

We use it to switch to "COS_CONTAINERD" which is COS using containerd instead of docker.

Other people might want to use Ubuntu workers.

All options can be seen here: https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#available_node_images

Defaults to the current value.