### PR TITLE
Fixed coordinates example value to a valid one

### DIFF
--- a/k8s/base/indexer-agent/deployment.yaml
+++ b/k8s/base/indexer-agent/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - name: INDEXER_AGENT_PUBLIC_INDEXER_URL
               value: http://indexer.domain/
             - name: INDEXER_AGENT_INDEXER_GEO_COORDINATES
-              value: "37.630768,-119.032631"
+              value: "37.630768 -119.032631"
             - name: INDEXER_AGENT_NETWORK_SUBGRAPH_ENDPOINT
               value: https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-rinkeby
             - name: INDEXER_AGENT_POSTGRES_HOST


### PR DESCRIPTION
Old value was causing the following error on pod startup:
```
Invalid --indexer-geo-coordinates provided. Must be of format e.g.: 31.780715 -41.179504
```