### PR TITLE
Update indexer-service base deployment.yaml

### DIFF
--- a/k8s/base/indexer-service/deployment.yaml
+++ b/k8s/base/indexer-service/deployment.yaml
@@ -46,6 +46,23 @@ spec:
               value: http://query-node.default.svc.cluster.local/index-node/graphql
             - name: INDEXER_SERVICE_NETWORK_SUBGRAPH_ENDPOINT
               value: https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-testnet-phase2
+            - name: INDEXER_SERVICE_POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: host
+            - name: INDEXER_SERVICE_POSTGRES_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: user
+            - name: INDEXER_SERVICE_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: INDEXER_SERVICE_POSTGRES_DATABASE
+              value: indexer-service
             - name: SERVER_HOST
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
This fixes the `Missing required arguments: postgres-host, postgres-database` error on k8s setups.