### PR TITLE
Include a note in main README about the new deployment ID conversion tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ For NPM registry access, see the [NPM registry guide](guides/npm-registry.md).
 
 - **2020-10-16: [GDAI to GRT conversation utility for cost models](./utils/gdai-to-grt/).**
 
-- **2020-10-20: [Graph Node v0.19.0 release allows to disable EIP-1898](./updates/2020-10-20-graph-node-v0.19.2.md)**
+- **2020-10-20: [Graph Node v0.19.0 release allows to disable EIP-1898](./updates/2020-10-20-graph-node-v0.19.2.md).**
+R
+- **2020-10-21: [Subgraph Deployment ID conversion utility](./utils/subgraph-deployment-id-conversions).**
 
 ## Main Changes
 


### PR DESCRIPTION
Note the new subgraph deployment ID utility in the `Important Updates` section.